### PR TITLE
Support for multiple handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mocha": "*",
     "supertest": "*",
     "should": "*",
-    "koa": "koajs/koa"
+    "koa": "*"
   },
   "license": "MIT",
   "dependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@
 var request = require('supertest');
 var koa = require('koa');
 
-var methods = require('methods').map(function(method){
+var methods = require('methods').map(function (method) {
   // normalize method names for tests
   if (method == 'delete') method = 'del';
   if (method == 'connect') return; // WTF
@@ -11,95 +11,97 @@ var methods = require('methods').map(function(method){
 
 var route = require('..');
 
-methods.forEach(function(method){
+methods.forEach(function(method) {
   var app = koa();
-  app.use(route[method]('/:user(tj)', function*(user){
+
+  app.use(route[method]('/:user(tj)', function* (user) {
     this.body = user;
-  }))
+  }));
 
-  describe('route.' + method + '()', function(){
-    describe('when method and path match', function(){
-      it('should 200', function(done){
+  describe('route.' + method + '()', function () {
+    describe('when method and path match', function () {
+      it('should 200', function (done){
         request(app.listen())
-        [method]('/tj')
-        .expect(200)
-        .expect(method === 'head' ? '' : 'tj', done);
-      })
-    })
+          [method]('/tj')
+          .expect(200)
+          .expect(method === 'head' ? '' : 'tj', done);
+      });
+    });
 
-    describe('when only method matches', function(){
-      it('should 404', function(done){
+    describe('when only method matches', function () {
+      it('should 404', function (done) {
         request(app.listen())
-        [method]('/tjayyyy')
-        .expect(404, done);
-      })
-    })
+          [method]('/tjayyyy')
+          .expect(404, done);
+      });
+    });
 
-    describe('when only path matches', function(){
-      it('should 404', function(done){
+    describe('when only path matches', function () {
+      it('should 404', function (done) {
         request(app.listen())
-        [method === 'get' ? 'post' : 'get']('/tj')
-        .expect(404, done);
-      })
-    })
-  })
-})
+          [method === 'get' ? 'post' : 'get']('/tj')
+          .expect(404, done);
+      });
+    });
+  });
+});
 
-describe('route.all()', function(){
-  describe('should work with', function(){
-    methods.forEach(function(method){
+describe('route.all()', function () {
+  describe('should work with', function () {
+    methods.forEach(function (method){
       var app = koa();
-      app.use(route.all('/:user(tj)', function*(user){
+
+      app.use(route.all('/:user(tj)', function* (user){
         this.body = user;
       }))
 
-      it(method, function(done){
+      it(method, function (done){
         request(app.listen())
-        [method]('/tj')
-        .expect(200)
-        .expect(method === 'head' ? '' : 'tj', done);
-      })
-    })
-  })
+          [method]('/tj')
+          .expect(200)
+          .expect(method === 'head' ? '' : 'tj', done);
+      });
+    });
+  });
 
-  describe('when patch does not match', function(){
-    it('should 404', function (done){
+  describe('when patch does not match', function () {
+    it('should 404', function (done) {
       var app = koa();
-      app.use(route.all('/:user(tj)', function*(user){
+      app.use(route.all('/:user(tj)', function* (user) {
         this.body = user;
-      }))
+      }));
 
       request(app.listen())
-      .get('/tjayyyyyy')
-      .expect(404, done);
-    })
-  })
-})
+        .get('/tjayyyyyy')
+        .expect(404, done);
+    });
+  });
+});
 
-describe('route params', function(){
-  methods.forEach(function(method){
+describe('route params', function () {
+  methods.forEach(function (method) {
     var app = koa();
 
-    app.use(route[method]('/:user(tj)', function*(user, next){
+    app.use(route[method]('/:user(tj)', function* (user, next) {
       yield next;
-    }))
+    }));
 
-    app.use(route[method]('/:user(tj)', function*(user, next){
+    app.use(route[method]('/:user(tj)', function* (user, next) {
       this.body = user;
       yield next;
     }))
 
-    app.use(route[method]('/:user(tj)', function*(user, next){
+    app.use(route[method]('/:user(tj)', function* (user, next) {
       this.status = 201;
     }))
 
-    it('should work with method ' + method, function(done){
+    it('should work with method ' + method, function (done){
       request(app.listen())
         [method]('/tj')
         .expect(201)
         .expect(method === 'head' ? '' : 'tj', done);
-    })
-  })
+    });
+  });
 
   it('should be decoded', function(done){
     var app = koa();
@@ -110,7 +112,64 @@ describe('route params', function(){
     }));
 
     request(app.listen())
-    .get('/package/' + encodeURIComponent('http://github.com/component/tip'))
-    .end(function(){});
-  })
-})
+      .get('/package/' + encodeURIComponent('http://github.com/component/tip'))
+      .end(function(){});
+  });
+});
+
+describe('multiple route fns', function () {
+  it('should handle more than one fn', function (done) {
+    var app = koa();
+
+    function* intermediateFn (name) {
+      name.should.equal('hallas');
+    }
+
+    app.use(route.get('/users/:name', intermediateFn, function* (name) {
+      name.should.equal('hallas');
+      done();
+    }));
+
+    request(app.listen())
+      .get('/users/hallas')
+      .end(function() {});
+  });
+
+  it('should throw in intermediate', function (done) {
+    var app = koa();
+
+    function* intermediateFn (name) {
+      try {
+        this.throw('intermediate error');
+      } catch (err) {
+        err.should.be.an.Error;
+      }
+    }
+
+    app.use(route.get('/users/:name', intermediateFn, function* (name) {
+      name.should.equal('hallas');
+      done();
+    }));
+
+    request(app.listen())
+      .get('/users/hallas')
+      .end(function() {});
+  });
+
+  it('should pass ctx along', function (done) {
+    var app = koa();
+
+    function* intermediateFn (firstName, lastName) {
+      this.fullName = firstName + ' ' + lastName;
+    }
+
+    app.use(route.get('/users/:first/:last', intermediateFn, function* (first, last) {
+      this.fullName.should.equal(first + ' ' + last);
+      done();
+    }));
+
+    request(app.listen())
+      .get('/users/chris/hallas')
+      .end(function() {});
+  });
+});


### PR DESCRIPTION
Added three tests for this. This allows us to have `route.get(path, fn1, fn2,
fnN)` but only the last handler, `fnN` will receive the next generator.
This is very useful for adding little permission checks or something
similar to your routes, they can then throw to disrupt the middleware.

Also removed soft dependency on the koa repo in favor for \* from npm.
