### PR TITLE
Fix: make null the unmatched optional parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ function create(method) {
 
       // path
       if (m = re.exec(this.path)) {
-        var args = m.slice(1).map(decodeURIComponent);
+        var args = m.slice(1).map(function (item) {
+          return (item ? decodeURIComponent(item) : null)
+        });
         debug('%s %s matches %s %j', this.method, path, this.path, args);
         args.push(next);
         yield fn.apply(this, args);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "koa-route",
   "description": "Koa route middleware",
   "repository": "koajs/route",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "keywords": [
     "koa",
     "middleware",

--- a/test/test.js
+++ b/test/test.js
@@ -113,4 +113,18 @@ describe('route params', function(){
     .get('/package/' + encodeURIComponent('http://github.com/component/tip'))
     .end(function(){});
   })
+
+  it('should be null if not matched', function(done){
+    var app = koa();
+
+    app.use(route.get('/api/:resource/:id?', function *(resource, id){
+      resource.should.equal('users');
+      (id == null).should.be.true;
+      done();
+    }));
+
+    request(app.listen())
+    .get('/api/users')
+    .end(function(){});
+  })
 })


### PR DESCRIPTION
Fixes the following:

```
route.get('/:resource/:id?', function (resource, id) {
  // resource === 'users'
  // id === 'undefined'   <-- a string
}}

request.get('/users')
```
