### PR TITLE
handle head method when get is defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function create(method) {
       var m;
 
       // method
-      if (method && method != this.method) return yield next;
+      if (validMethods(this.method).indexOf(method) == -1) return yield next;
 
       // path
       if (m = re.exec(this.path)) {
@@ -48,4 +48,14 @@ function create(method) {
 
 function decode(val) {
   if (val) return decodeURIComponent(val);
+}
+
+/**
+ * Check request method.
+ */
+
+function validMethods(method) {
+  var arr = [undefined, method];
+  if (method == 'HEAD') arr.push('GET');
+  return arr;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -101,6 +101,18 @@ describe('route params', function(){
     })
   })
 
+  it('should work with method head when get is defined', function(done){
+    var app = koa();
+
+    app.use(route.get('/tj', function *(name){
+      this.body = 'foo';
+    }));
+
+    request(app.listen())
+    ['head']('/tj')
+    .expect(200, done)
+  })
+
   it('should be decoded', function(done){
     var app = koa();
 


### PR DESCRIPTION
Fix for https://github.com/koajs/route/issues/17.

Here is what the documentation says:

> The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response. The metainformation contained in the HTTP headers in response to a HEAD request SHOULD be identical to the information sent in response to a GET request. This method can be used for obtaining metainformation about the entity implied by the request without transferring the entity-body itself.

Based on the description above the module works as expected and this is not a bug. Since `koa` core handles HEAD, as @visionmedia mentioned, I created the PR anyway (useful).
