### PR TITLE
Add opts argument to routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -17,8 +16,8 @@ exports.all = create();
 function create(method) {
   if (method) method = method.toUpperCase();
 
-  return function(path, fn){
-    var re = pathToRegexp(path);
+  return function(path, fn, opts){
+    var re = pathToRegexp(path, opts);
     debug('%s %s -> %s', method, path, re);
 
     return function *(next){

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,3 @@
-
 var request = require('supertest');
 var koa = require('koa');
 
@@ -126,5 +125,19 @@ describe('route params', function(){
     request(app.listen())
     .get('/api/users')
     .end(function(){});
+  })
+
+  it('should use the given options', function(done){
+    var app = koa();
+
+    app.use(route.get('/api/:resource/:id', function *(resource, id){
+      resource.should.equal('users');
+      id.should.equal('1')
+      done();
+    }, { end: false }));
+
+    request(app.listen())
+      .get('/api/users/1/posts')
+      .end(function(){});
   })
 })


### PR DESCRIPTION
Issue I'm currently hitting is:

I have a set of routes that have the same prefix, e.g. 

```
GET /:owner/:project
GET /:owner/:project/owner
POST /:owner/:project/collaborators
```

etc. and I want a couple of middleware fns to get/set this.project and this.account by the :owner and :project parsed from the path.

```
koa()
    .use(route.all('/:owner/:project', setProject))
    .use(route.all('/:owner/:project', setOwner))
    .use(route.post('/:owner/:project/owner', addCollaborator))
    ...
```

problem is that koa-route uses path-to-regexp and by default, path-to-regexp matches from the end. so those middleware fns will only match the first route of my examples.

so we need a way to pass options to path-to-regexp and that's what this pr is for. so that you can configure how the route you're making will behave/be parsed.

will this pr you'll be able to do:

```
koa()
    .use(route.all('/:owner/:project', setProject, { end: false }))
    .use(route.all('/:owner/:project', setOwner, { end: false }))
    .use(route.post('/:owner/:project/owner', addCollaborator))
    ...
```

and all those examples will work. I've added a test for this as well.
