### PR TITLE
Add support for prefixing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,8 +45,13 @@ var pets = {
   }
 };
 
-app.use(_.get('/pets', pets.list));
-app.use(_.get('/pets/:name', pets.show));
+/* Create a nested prefix */
+var api = _('/api');
+var pets = api('/pets')
+
+/* Now we listen to the routes /api/pets and /api/pets/:name */
+app.use(pets.get(pets.list));
+app.use(pets.get('/:name', pets.show));
 
 app.listen(3000);
 console.log('listening on port 3000');

--- a/example.js
+++ b/example.js
@@ -22,8 +22,13 @@ var pets = {
   }
 };
 
-app.use(r.get('/pets', pets.list));
-app.use(r.get('/pets/:name', pets.show));
+/* Create a nested prefix */
+var api = r('/api');
+var pets = api('/pets')
+
+/* Now we listen to the routes /api/pets and /api/pets/:name */
+app.use(pets.get(pets.list));
+app.use(pets.get('/:name', pets.show));
 
 app.listen(3000);
 console.log('listening on port 3000');

--- a/test/test.js
+++ b/test/test.js
@@ -8,15 +8,50 @@ var methods = require('methods').map(function(method){
   return method;
 }).filter(Boolean)
 
+var prefix = '/prefix';
 var route = require('..');
-var prefixed = route('/prefix');
+var prefixed = route(prefix);
 
 describe('when simply required', function() {
   setupSuite(route, '');
 });
 
 describe('when prefixed', function() {
-  setupSuite(prefixed, '/prefix');
+  setupSuite(prefixed, prefix);
+
+  methods.forEach(function(method){
+    var app = koa();
+    app.use(prefixed[method](function*(){
+      this.body = 'tj';
+    }))
+
+    describe('route.' + method + '()', function(){
+      describe('when method and path match', function(){
+        it('should 200', function(done){
+          request(app.listen())
+          [method](prefix)
+          .expect(200)
+          .expect(method === 'head' ? '' : 'tj', done);
+        })
+      })
+
+      describe('when only method matches', function(){
+        it('should 404', function(done){
+          request(app.listen())
+          [method](prefix + '/tjayyyy')
+          .expect(404, done);
+        })
+      })
+
+      describe('when only path matches', function(){
+        it('should 404', function(done){
+          request(app.listen())
+          [method === 'get' ? 'post' : 'get'](prefix)
+          .expect(404, done);
+        })
+      })
+    })
+  })
 });
 
 function setupSuite(route, prefix) {

--- a/test/test.js
+++ b/test/test.js
@@ -9,147 +9,158 @@ var methods = require('methods').map(function(method){
 }).filter(Boolean)
 
 var route = require('..');
+var prefixed = route('/prefix');
 
-methods.forEach(function(method){
-  var app = koa();
-  app.use(route[method]('/:user(tj)', function*(user){
-    this.body = user;
-  }))
+describe('when simply required', function() {
+  setupSuite(route, '');
+});
 
-  describe('route.' + method + '()', function(){
-    describe('when method and path match', function(){
-      it('should 200', function(done){
-        request(app.listen())
-        [method]('/tj')
-        .expect(200)
-        .expect(method === 'head' ? '' : 'tj', done);
-      })
-    })
+describe('when prefixed', function() {
+  setupSuite(prefixed, '/prefix');
+});
 
-    describe('when only method matches', function(){
-      it('should 404', function(done){
-        request(app.listen())
-        [method]('/tjayyyy')
-        .expect(404, done);
-      })
-    })
-
-    describe('when only path matches', function(){
-      it('should 404', function(done){
-        request(app.listen())
-        [method === 'get' ? 'post' : 'get']('/tj')
-        .expect(404, done);
-      })
-    })
-  })
-})
-
-describe('route.all()', function(){
-  describe('should work with', function(){
-    methods.forEach(function(method){
-      var app = koa();
-      app.use(route.all('/:user(tj)', function*(user){
-        this.body = user;
-      }))
-
-      it(method, function(done){
-        request(app.listen())
-        [method]('/tj')
-        .expect(200)
-        .expect(method === 'head' ? '' : 'tj', done);
-      })
-    })
-  })
-
-  describe('when patch does not match', function(){
-    it('should 404', function (done){
-      var app = koa();
-      app.use(route.all('/:user(tj)', function*(user){
-        this.body = user;
-      }))
-
-      request(app.listen())
-      .get('/tjayyyyyy')
-      .expect(404, done);
-    })
-  })
-})
-
-describe('route params', function(){
+function setupSuite(route, prefix) {
   methods.forEach(function(method){
     var app = koa();
-
-    app.use(route[method]('/:user(tj)', function*(user, next){
-      yield next;
-    }))
-
-    app.use(route[method]('/:user(tj)', function*(user, next){
+    app.use(route[method]('/:user(tj)', function*(user){
       this.body = user;
-      yield next;
     }))
 
-    app.use(route[method]('/:user(tj)', function*(user, next){
-      this.status = 201;
-    }))
+    describe('route.' + method + '()', function(){
+      describe('when method and path match', function(){
+        it('should 200', function(done){
+          request(app.listen())
+          [method](prefix + '/tj')
+          .expect(200)
+          .expect(method === 'head' ? '' : 'tj', done);
+        })
+      })
 
-    it('should work with method ' + method, function(done){
-      request(app.listen())
-        [method]('/tj')
-        .expect(201)
-        .expect(method === 'head' ? '' : 'tj', done);
+      describe('when only method matches', function(){
+        it('should 404', function(done){
+          request(app.listen())
+          [method](prefix + '/tjayyyy')
+          .expect(404, done);
+        })
+      })
+
+      describe('when only path matches', function(){
+        it('should 404', function(done){
+          request(app.listen())
+          [method === 'get' ? 'post' : 'get'](prefix + '/tj')
+          .expect(404, done);
+        })
+      })
     })
   })
 
-  it('should work with method head when get is defined', function(done){
-    var app = koa();
+  describe('route.all()', function(){
+    describe('should work with', function(){
+      methods.forEach(function(method){
+        var app = koa();
+        app.use(route.all('/:user(tj)', function*(user){
+          this.body = user;
+        }))
 
-    app.use(route.get('/tj', function *(name){
-      this.body = 'foo';
-    }));
+        it(method, function(done){
+          request(app.listen())
+          [method](prefix + '/tj')
+          .expect(200)
+          .expect(method === 'head' ? '' : 'tj', done);
+        })
+      })
+    })
 
-    request(app.listen())
-    ['head']('/tj')
-    .expect(200, done)
+    describe('when patch does not match', function(){
+      it('should 404', function (done){
+        var app = koa();
+        app.use(route.all('/:user(tj)', function*(user){
+          this.body = user;
+        }))
+
+        request(app.listen())
+        .get(prefix + '/tjayyyyyy')
+        .expect(404, done);
+      })
+    })
   })
 
-  it('should be decoded', function(done){
-    var app = koa();
+  describe('route params', function(){
+    methods.forEach(function(method){
+      var app = koa();
 
-    app.use(route.get('/package/:name', function *(name){
-      name.should.equal('http://github.com/component/tip');
-      done();
-    }));
+      app.use(route[method]('/:user(tj)', function*(user, next){
+        yield next;
+      }))
 
-    request(app.listen())
-    .get('/package/' + encodeURIComponent('http://github.com/component/tip'))
-    .end(function(){});
-  })
+      app.use(route[method]('/:user(tj)', function*(user, next){
+        this.body = user;
+        yield next;
+      }))
 
-  it('should be null if not matched', function(done){
-    var app = koa();
+      app.use(route[method]('/:user(tj)', function*(user, next){
+        this.status = 201;
+      }))
 
-    app.use(route.get('/api/:resource/:id?', function *(resource, id){
-      resource.should.equal('users');
-      (id == null).should.be.true;
-      done();
-    }));
+      it('should work with method ' + method, function(done){
+        request(app.listen())
+          [method](prefix + '/tj')
+          .expect(201)
+          .expect(method === 'head' ? '' : 'tj', done);
+      })
+    })
 
-    request(app.listen())
-    .get('/api/users')
-    .end(function(){});
-  })
+    it('should work with method head when get is defined', function(done){
+      var app = koa();
 
-  it('should use the given options', function(done){
-    var app = koa();
+      app.use(route.get('/tj', function *(name){
+        this.body = 'foo';
+      }));
 
-    app.use(route.get('/api/:resource/:id', function *(resource, id){
-      resource.should.equal('users');
-      id.should.equal('1')
-      done();
-    }, { end: false }));
+      request(app.listen())
+      ['head'](prefix + '/tj')
+      .expect(200, done)
+    })
 
-    request(app.listen())
-      .get('/api/users/1/posts')
+    it('should be decoded', function(done){
+      var app = koa();
+
+      app.use(route.get('/package/:name', function *(name){
+        name.should.equal('http://github.com/component/tip');
+        done();
+      }));
+
+      request(app.listen())
+      .get(prefix + '/package/' + encodeURIComponent('http://github.com/component/tip'))
       .end(function(){});
+    })
+
+    it('should be null if not matched', function(done){
+      var app = koa();
+
+      app.use(route.get('/api/:resource/:id?', function *(resource, id){
+        resource.should.equal('users');
+        (id == null).should.be.true;
+        done();
+      }));
+
+      request(app.listen())
+      .get(prefix + '/api/users')
+      .end(function(){});
+    })
+
+    it('should use the given options', function(done){
+      var app = koa();
+
+      app.use(route.get('/api/:resource/:id', function *(resource, id){
+        resource.should.equal('users');
+        id.should.equal('1')
+        done();
+      }, { end: false }));
+
+      request(app.listen())
+        .get(prefix + '/api/users/1/posts')
+        .end(function(){});
+    })
   })
-})
+}


### PR DESCRIPTION
Hi, so today I realised, that I would love to define prefixes for sets of routes.
This PR therefore allows for the following:

``` js
var _ = require('koa-route');
// Lets create a prefix
var api = _('/api');

// We can nest prefixes if we want to
var v1 = api('/v1');

// Or define them directly
var v2 = _('/api/v2');

// /api/v1/some/route
koa.use(v1.get('/some/route', route));

// /api/v1/some/:parameterized/route
koa.use(v1.get('/some/:parameterized/route', route));

// /api/v2
koa.use(v2.all(route));

// /api/v2/
koa.use(v2.all('/', route));

// This still works
koa.use(_.get('/some/view', view));
```

I hope this change does not increase the scope of this module too much for your taste.
I changed the readme and example.js as well as the tests, to acommondate the new feature.
I am not sure about the way I restructured the tests though, I just ran all of them twice, once with a prefix and one without.

Please let me know if you like the idea, and if neccessary, which changes would need to be made to land this PR.
