### PR TITLE
Routes can now be partially applied

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,22 +23,30 @@ function create(method) {
     const re = pathToRegexp(path, opts);
     debug('%s %s -> %s', method || 'ALL', path, re);
 
-    return function (ctx, next){
-      // method
-      if (!matches(ctx, method)) return next();
+    const createRoute = function(routeFunc){
+      return function (ctx, next){
+        // method
+        if (!matches(ctx, method)) return next();
 
-      // path
-      const m = re.exec(ctx.path);
-      if (m) {
-        const args = m.slice(1).map(decode);
-        debug('%s %s matches %s %j', ctx.method, path, ctx.path, args);
-        args.unshift(ctx);
-        args.push(next);
-        return Promise.resolve(fn.apply(ctx, args));
+        // path
+        const m = re.exec(ctx.path);
+        if (m) {
+          const args = m.slice(1).map(decode);
+          debug('%s %s matches %s %j', ctx.method, path, ctx.path, args);
+          args.unshift(ctx);
+          args.push(next);
+          return Promise.resolve(routeFunc.apply(ctx, args));
+        }
+
+        // miss
+        return next();
       }
+    };
 
-      // miss
-      return next();
+    if (fn) {
+      return createRoute(fn);
+    } else {
+      return createRoute;
     }
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,41 @@ methods.forEach(function(method){
   })
 })
 
+methods.forEach(function(method){
+  const app = new Koa();
+  app.use(route[method]('/:user(tj)')(function(ctx, user){
+    ctx.body = user;
+  }))
+
+  describe('composed: route.' + method + '()', function(){
+    describe('when method and path match', function(){
+      it('should 200', function(done){
+        request(app.listen())
+        [method]('/tj')
+        .expect(200)
+        .expect(method === 'head' ? '' : 'tj', done);
+      })
+    })
+
+    describe('composed: when only method matches', function(){
+      it('should 404', function(done){
+        request(app.listen())
+        [method]('/tjayyyy')
+        .expect(404, done);
+      })
+    })
+
+    describe('composed: when only path matches', function(){
+      it('should 404', function(done){
+        request(app.listen())
+        [method === 'get' ? 'post' : 'get']('/tj')
+        .expect(404, done);
+      })
+    })
+  })
+})
+
+
 describe('route.all()', function(){
   describe('should work with', function(){
     methods.forEach(function(method){


### PR DESCRIPTION
This adds the ability to partially apply a route. This maintains total backwards compatibility. Ex:
```js
app.use(route.get('/example')(function(ctx) {
  // ...
}))
```

I have added tests mirroring the normal ones, which all pass.