### PR TITLE
Teach route to squeeze backslashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,23 @@ methods.forEach(function(method){
 module.exports.del = module.exports.delete;
 module.exports.all = create();
 
+function squeezeBackslashes(str){
+  return str.replace(/(\/{2,})/g, '/');
+}
+
+function sanitizePath(path){
+  if (typeof path !== 'string') {
+    throw new Error('invalid path');
+  }
+  return squeezeBackslashes(path);
+}
+
 function create(method) {
   if (method) method = method.toUpperCase();
 
   return function(path, fn, opts){
+    path = sanitizePath(path);
+
     const re = pathToRegexp(path, opts);
     debug('%s %s -> %s', method || 'ALL', path, re);
 
@@ -29,7 +42,7 @@ function create(method) {
         if (!matches(ctx, method)) return next();
 
         // path
-        const m = re.exec(ctx.path);
+        const m = re.exec(sanitizePath(ctx.path));
         if (m) {
           const args = m.slice(1).map(decode);
           ctx.routePath = path;

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@
 
 const request = require('supertest');
 const Koa = require('koa');
+const should = require('should');
 
 const methods = require('methods').map(function(method){
   // normalize method names for tests
@@ -203,6 +204,37 @@ describe('routePath is added to ctx', function(){
 
     request(app.listen())
       .get('/tj/val')
+      .end(function(){});
+  })
+})
+
+describe('path sanitization', function(){
+  context('when path is not a string', function() {
+    it('should throw "invalid path" error', function(){
+      const app = new Koa();
+
+      should(function () {
+        route.get(null, function (ctx, name) {})
+      })
+      .throw('invalid path');
+
+      should(function () {
+        route.get(undefined, function (ctx, name) {})
+      })
+      .throw('invalid path');
+    })
+  })
+
+  it('should squash multiple consequtive backslashes', function(done){
+    const app = new Koa();
+
+    app.use(route.get('//tj///:var', function (ctx, name){
+      ctx.routePath.should.equal('/tj/:var');
+      done();
+    }));
+
+    request(app.listen())
+      .get('//tj/val')
       .end(function(){});
   })
 })


### PR DESCRIPTION
- Sanitise paths during route declaration and matching
- Add basic error handling during sanitization

That way accidental inbound requests such as `http://foo.com//path/to/server` will match `/path/to/server` and be routed successfully.