### PR TITLE
update readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ app.use(_.get('/pets', pets.list));
 app.use(_.get('/pets/:name', pets.show));
 ```
 
- If you need a full-featured solution check out [koa-router](https://github.com/alexmingoia/koa-router),
+ If you need a full-featured solution check out [koa-router](https://github.com/koajs/router),
  a Koa clone of express-resource.
 
 ## Installation


### PR DESCRIPTION
old koajs-router was linked in readme. In order to avoid confusion which version people can look at, link is updated to point to https://github.com/koajs/router instead of old https://github.com/alexmingoia/koa-router